### PR TITLE
Use raw link for image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin provides themes for napari, which can be selected in the napari sett
 
 A warm and cozy theme with brownish colors, intended to introduce a gray canvas for different visualizations.
 
-![ndev-cozy theme](./resources/ndev-cozy.png)
+![ndev-cozy theme](https://raw.githubusercontent.com/ndev-kit/ndev-themes/main/resources/ndev-cozy.png)
 
 ## Installation
 


### PR DESCRIPTION
# Description

Currently, the image does not show on PyPI or napari hub because it is not an absolute url.

See napari/docs#906 
